### PR TITLE
Fix Photino.NET runtime dependencies and UI dist file tracking

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -42,3 +42,15 @@ dotnet tool restore
 # --- Build everything (also runs `yarn install` + protobuf/TS codegen for
 #     Zylance.Contract and Zylance.UI via their MSBuild targets) ---
 dotnet build --no-restore
+
+# --- Runtime deps for running/screenshotting Zylance.Desktop (Photino.NET) ---
+# Photino.NET embeds a WebView backed by WebKitGTK on Linux, and its native
+# lib also links libnotify; the base image doesn't ship either. scrot
+# captures the Xvfb framebuffer for screenshots. xdotool resizes/positions
+# the window: with SetUseOsDefaultSize/Location and no window manager on
+# Xvfb, Photino's window opens tiny (~200x200) in the top-left corner.
+# Xvfb itself is already present on the base image.
+if ! ldconfig -p | grep -q libwebkit2gtk-4.1; then
+  apt-get update -qq
+  apt-get install -y -qq libwebkit2gtk-4.1-0 libnotify4 scrot xdotool
+fi

--- a/src/Zylance.Desktop/Zylance.Desktop.csproj
+++ b/src/Zylance.Desktop/Zylance.Desktop.csproj
@@ -28,7 +28,6 @@
   <!-- Collect UI dist files for incremental build tracking -->
   <ItemGroup>
     <UIDistFiles Include="..\Zylance.UI\dist\**\*" />
-    <UIDistFiles Remove="..\Zylance.UI\dist\**" />
   </ItemGroup>
 
   <Target


### PR DESCRIPTION
## Summary
This PR addresses two issues: ensuring Photino.NET runtime dependencies are available in the build environment, and fixing incremental build tracking for UI distribution files.

## Key Changes
- **Runtime dependencies for Photino.NET**: Added installation of required native libraries (`libwebkit2gtk-4.1-0`, `libnotify4`) and utilities (`scrot`, `xdotool`) to the session initialization script. These are necessary for running and screenshotting the Zylance.Desktop application (which uses Photino.NET WebView) in the CI environment with Xvfb.
  - Includes conditional check to avoid reinstalling if dependencies already present
  - Added detailed comments explaining the purpose of each dependency

- **UI dist file tracking**: Removed the `UIDistFiles Remove` directive from the project file that was inadvertently clearing the collected UI distribution files, which was breaking incremental build tracking.

## Implementation Details
The Photino.NET setup includes:
- `libwebkit2gtk-4.1-0`: WebView implementation for Linux (embedded by Photino.NET)
- `libnotify4`: Native library linked by Photino.NET
- `scrot`: For capturing Xvfb framebuffer screenshots
- `xdotool`: For window management (resizing/positioning) since Photino opens in a small default size without a window manager on Xvfb

https://claude.ai/code/session_01KCyWsonMVjYo9zRm9B2AmA